### PR TITLE
[windows] Make absh work on Windows

### DIFF
--- a/src/sh.rs
+++ b/src/sh.rs
@@ -2,9 +2,18 @@ use std::process::Child;
 use std::process::Command;
 use std::process::Stdio;
 
+#[cfg(not(windows))]
 pub fn spawn_sh(script: &str) -> anyhow::Result<Child> {
     Ok(Command::new("/bin/sh")
-        .args(&["-ec", &script])
+        .args(&["-c", &script])
+        .stdin(Stdio::null())
+        .spawn()?)
+}
+
+#[cfg(windows)]
+pub fn spawn_sh(script: &str) -> anyhow::Result<Child> {
+    Ok(Command::new("powershell.exe")
+        .args(&["-Command", &script])
         .stdin(Stdio::null())
         .spawn()?)
 }


### PR DESCRIPTION
I love this tool, thank you for making it :)

This PR fills in the missing pieces to make absh build and run on Windows. Only two parts needed tweaking:

1. The last run log is targeted with the `last` symlink; this PR implements this on Windows by doing the same thing as Unix does and symlinking the file. This is a privileged operation on Windows and won't work unless a user is in an admin prompt or has been given the right to create symlinks some other way.
2. `spawn_sh` shells out to `/bin/sh`; I added an implementation that does the same to `powershell.exe`.

With that, I got absh running on my Windows 11 machine:

```
running test: A
running script:
    echo hi
hi
A finished in 0.135 s, max rss 60 MiB

running test: B
running script:
    echo hi
hi
B finished in 0.136 s, max rss 60 MiB

Time (in seconds):
A: n=49 mean=0.138 std=0.005 se=0.000 min=0.133 max=0.170 med=0.136
B: n=49 mean=0.137 std=0.004 se=0.000 min=0.134 max=0.168 med=0.136
A: distr=[  ▁▃█▄▂▁▁▂ ▁   ▁                                        ]
B: distr=[  ▂▄▇▅▄▂ ▁▂   ▁                                         ]
B/A: 0.995 0.979..1.011 (95% conf)
```