### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ B/A: 0.979 0.975..0.983 (95% conf)
 ## How to install
 
 ```sh
-cargo install --git https://github.com/stepancheg/absh
+cargo install --git https://github.com/stepancheg/absh absh
 ```
 
 Cargo is a Rust package manager and build system. It can be downloaded [from rustup.rs](https://rustup.rs/).


### PR DESCRIPTION
Cargo failing with 
```
cargo install --git https://github.com/stepancheg/absh
    Updating git repository `https://github.com/stepancheg/absh`
error: multiple packages with binaries found: absh, xtask. When installing a git repository, cargo will always search the entire repo for any Cargo.toml.
Please specify a package, e.g. `cargo install --git https://github.com/stepancheg/absh absh`.
```
this PR specifies binary